### PR TITLE
fix for console log URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,20 @@ The synchronization works like this
 * creating a new OpenShift Build for a BuildConfig associated with a Jenkins Job results in the Jenkins Job being triggered
 * changes in a Jenkins Build Run thats associated with a Jenkins Job gets replicated to an OpenShift Build object (which is created if necessary if the build was triggered via Jenkins)
 
+Configuration
+------------------------
+Jenkins Build Log URL:
+* This plugin adds an annotation to the OpenShift build configuration containing the Jenkins build log URL.
+By default, the Jenkins base URL for the build log is determined via the OpenShift route of the Jenkins service. To override and configure this base URL, you can set the environment variable `JENKINS_ROOT_URL`.
+This environment variable will get precedence than Jenkins service to determine base URL.
+For fabric8/OpenShift.io tenant's Jenkins deployment, the log base URL is configured through [DeploymentConfig environment variable](https://github.com/fabric8-services/fabric8-tenant-jenkins/blob/master/apps/jenkins/src/main/fabric8/openshift-deployment.yml#L39)
+
 Development Instructions
 ------------------------
 
 * Build and run the unit tests
   Execute `mvn clean install`
-  
+
 * Install the plugin into a locally-running Jenkins
   Execute `mvn hpi:run`
   Navigate in brower to `http://localhost:8080/jenkins`

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <log.level>INFO</log.level>
     <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
     <findbugs.failOnError>false</findbugs.failOnError>
+    <github.system-rules>1.17.1</github.system-rules>
   </properties>
 
   <name>OpenShift Sync</name>
@@ -121,7 +122,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.9</version>
+      <version>2.1.13</version>
     </dependency>
 
     <dependency>
@@ -338,7 +339,22 @@
       <artifactId>kubernetes</artifactId>
       <version>0.10</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>${github.system-rules}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-server-mock</artifactId>
+      <version>${openshift-client.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
+
 
   <build>
     <plugins>

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
@@ -84,6 +84,7 @@ import static java.util.logging.Level.WARNING;
 @Extension
 public class BuildSyncRunListener extends RunListener<Run> {
   private static final Logger logger = Logger.getLogger(BuildSyncRunListener.class.getName());
+  public static final String JENKINS_ROOT_URL_ENV_VAR = "JENKINS_ROOT_URL";
 
   private long pollPeriodMs = 1000;
   private String namespace;
@@ -258,7 +259,7 @@ public class BuildSyncRunListener extends RunListener<Run> {
     }
 
     OpenShiftClient openShiftClient = getOpenShiftClient();
-    String rootUrl = OpenShiftUtils.getJenkinsURL(openShiftClient, namespace);
+    String rootUrl = getHostName(openShiftClient, namespace);
     String buildUrl = joinPaths(rootUrl, run.getUrl());
     String logsUrl = joinPaths(buildUrl, "/consoleText");
 
@@ -394,6 +395,16 @@ public class BuildSyncRunListener extends RunListener<Run> {
           throw e;
         }
       }
+    }
+  }
+
+  /*Fix for jenkins proxy/idler introduction to get the right URL for console*/
+  public static String getHostName(OpenShiftClient openShiftClient, String namespace) {
+    String rootUrlFromEnvVar = System.getenv(JENKINS_ROOT_URL_ENV_VAR);
+    if(rootUrlFromEnvVar != null) {
+      return rootUrlFromEnvVar.trim();
+    } else {
+      return OpenShiftUtils.getJenkinsURL(openShiftClient, namespace);
     }
   }
 

--- a/src/test/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListenerTest.java
+++ b/src/test/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListenerTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fabric8.jenkins.openshiftsync;
+
+import io.fabric8.kubernetes.api.model.RootPaths;
+import io.fabric8.openshift.api.model.RouteBuilder;
+import io.fabric8.openshift.api.model.RouteList;
+import io.fabric8.openshift.api.model.RouteListBuilder;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BuildSyncRunListenerTest {
+
+  @Rule
+  public final org.junit.contrib.java.lang.system.EnvironmentVariables environmentVariables = new org.junit.contrib.java.lang.system.EnvironmentVariables();
+
+  @Test
+  public void should_get_hostname_from_env_var() {
+    // given
+    OpenShiftClient openShiftClient = new DefaultOpenShiftClient();
+    environmentVariables.set(BuildSyncRunListener.JENKINS_ROOT_URL_ENV_VAR, "http://proxy.openshift.io");
+
+    // when
+    String url = BuildSyncRunListener.getHostName(openShiftClient, "default");
+
+    //then
+    assertEquals("http://proxy.openshift.io", url);
+  }
+
+  @Test
+  public void should_get_hostname_from_openshift_service() {
+    // given
+    RouteList routeList = new RouteListBuilder()
+      .addToItems(
+        new RouteBuilder()
+          .withNewSpec()
+          .withNewTo()
+          .withKind("Service")
+          .withName("jenkins")
+          .endTo()
+          .withHost("jenkins.openshift.io")
+          .endSpec()
+          .build())
+      .build();
+    OpenShiftMockServer openShiftServer = mockOpenshiftJenkinsRoutes(routeList);
+
+    // when
+    String url = BuildSyncRunListener.getHostName(openShiftServer.createOpenShiftClient(), "default");
+
+    // then
+    assertEquals("http://jenkins.openshift.io", url);
+  }
+
+  private OpenShiftMockServer mockOpenshiftJenkinsRoutes(RouteList routeList) {
+    OpenShiftMockServer openShiftServer = new OpenShiftMockServer(false);
+    RootPaths rootPaths = new RootPaths();
+    rootPaths.getPaths().add("/oapi");
+    openShiftServer.expect().get().withPath("/").andReturn(200, rootPaths).always();
+    openShiftServer.expect().get().withPath("/oapi/v1/namespaces/default/routes").andReturn(200, routeList).always();
+    return openShiftServer;
+  }
+}


### PR DESCRIPTION
1. With introduction of Jenkins ideler/proxy have to fix the console URL generation
With that higher precedence is given to ENV VAR having proxy URL, otherwise, URL of Jenkins service if it does exist in OpenShift
2. Increased poll timing from 1 seconds to 10 seconds. As it could flood too many API requests(GET/PATCH) to OpenShit API server

#11  