### PR TITLE
Fix the noise issue of updating build at a fixed interval of 5 sec

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildCause.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildCause.java
@@ -35,6 +35,12 @@ public class BuildCause extends Cause {
 
   private String buildConfigUid;
 
+  private int numStages = -1;
+
+  private int numFlowNodes = -1;
+
+  private long lastUpdateToOpenshift = -1;
+
   public BuildCause(String uid, String namespace, String name, String gitUri, String commit, String buildConfigUid) {
     this.uid = uid;
     this.namespace = namespace;
@@ -42,6 +48,13 @@ public class BuildCause extends Cause {
     this.gitUri = gitUri;
     this.commit = commit;
     this.buildConfigUid = buildConfigUid;
+  }
+
+  public BuildCause(String uid, String namespace, String name, String gitUri, String commit, String buildConfigUid, int numStages, int numFlowNodes, long lastUpdateToOpenshift) {
+    this( uid,  namespace,  name,  gitUri,  commit,  buildConfigUid);
+    this.numStages = numStages;
+    this.numFlowNodes = numFlowNodes;
+    this.lastUpdateToOpenshift = lastUpdateToOpenshift;
   }
 
   public BuildCause(Build build, String buildConfigUid) {
@@ -104,4 +117,29 @@ public class BuildCause extends Cause {
   public String getBuildConfigUid() {
     return buildConfigUid;
   }
+
+  public int getNumStages() {
+    return numStages;
+  }
+
+  public void setNumStages(int numStages) {
+    this.numStages = numStages;
+  }
+
+  public int getNumFlowNodes() {
+    return numFlowNodes;
+  }
+
+  public void setNumFlowNodes(int numFlowNodes) {
+    this.numFlowNodes = numFlowNodes;
+  }
+
+  public long getLastUpdateToOpenshift() {
+    return lastUpdateToOpenshift;
+  }
+
+  public void setLastUpdateToOpenshift(long lastUpdateToOpenshift) {
+    this.lastUpdateToOpenshift = lastUpdateToOpenshift;
+  }
+
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
@@ -72,6 +72,8 @@ public class BuildSyncRunListener extends RunListener<Run> {
   private long pollPeriodMs = 1000 * 5;  // 5 seconds
   private long delayPollPeriodMs = 1000; // 1 seconds
   private String namespace;
+  //Not used as we have disable this
+  //private static final long maxDelay = 30000;
 
   private transient Set<Run> runsToPoll = new CopyOnWriteArraySet<>();
 
@@ -208,6 +210,49 @@ public class BuildSyncRunListener extends RunListener<Run> {
     }
   }
 
+  private boolean shouldUpdateOpenShiftBuild(BuildCause cause, int latestStageNum, int latestNumFlowNodes, StatusExt status) {
+    long currTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+    logger.fine(String.format("shouldUpdateOpenShiftBuild current time %s last update %s current stage num &s last stage num %s" +
+        "current flow num %s last flow num %s status %s",
+      String.valueOf(currTime),
+      String.valueOf(cause.getLastUpdateToOpenshift()),
+      String.valueOf(latestStageNum),
+      String.valueOf(cause.getNumStages()),
+      String.valueOf(latestNumFlowNodes),
+      String.valueOf(cause.getNumFlowNodes()),
+      status.toString()));
+
+    // ** ToDO **
+    // Right now our use case is to not update if there is no change
+    // So Disabling the 30 sec time limit for our fork.
+    // Later we can make this configurable and do the changes in both
+    // fork and upstream
+
+    /*
+    // if we have not updated in maxDelay time, update
+    if (currTime > (cause.getLastUpdateToOpenshift() + maxDelay)) {
+      return true;
+    }*/
+
+    // if the num of stages has changed, update
+    if (cause.getNumStages() != latestStageNum) {
+      return true;
+    }
+
+    // if the num of flow nodes has changed, update
+    if (cause.getNumFlowNodes() != latestNumFlowNodes) {
+      return true;
+    }
+
+    // if the run is in some sort of terminal state, update
+    // Do not update if this is in input stage
+    if (status != StatusExt.IN_PROGRESS && status != StatusExt.PAUSED_PENDING_INPUT) {
+      return true;
+    }
+
+    return false;
+  }
+
   private void upsertBuild(Run run, RunExt wfRunExt) {
     if (run == null) {
       return;
@@ -251,6 +296,10 @@ public class BuildSyncRunListener extends RunListener<Run> {
     if (!wfRunExt.get_links().self.href.matches("^https?://.*$")) {
       wfRunExt.get_links().self.setHref(joinPaths(rootUrl, wfRunExt.get_links().self.href));
     }
+
+    int newNumStages = wfRunExt.getStages().size();
+    int newNumFlowNodes = 0;
+
     for (StageNodeExt stage : wfRunExt.getStages()) {
       FlowNodeExt.FlowNodeLinks links = stage.get_links();
       if (!links.self.href.matches("^https?://.*$")) {
@@ -259,6 +308,9 @@ public class BuildSyncRunListener extends RunListener<Run> {
       if (links.getLog() != null && !links.getLog().href.matches("^https?://.*$")) {
         links.getLog().setHref(joinPaths(rootUrl, links.getLog().href));
       }
+
+      newNumFlowNodes = newNumFlowNodes + stage.getStageFlowNodes().size();
+
       for (AtomFlowNodeExt node : stage.getStageFlowNodes()) {
         FlowNodeExt.FlowNodeLinks nodeLinks = node.get_links();
         if (!nodeLinks.self.href.matches("^https?://.*$")) {
@@ -272,6 +324,11 @@ public class BuildSyncRunListener extends RunListener<Run> {
       if (status != null && status.equals(StatusExt.PAUSED_PENDING_INPUT)) {
         pendingInput = true;
       }
+    }
+
+    boolean needToUpdate = this.shouldUpdateOpenShiftBuild(cause, newNumStages, newNumFlowNodes, wfRunExt.getStatus());
+    if (!needToUpdate) {
+      return;
     }
 
     String json;
@@ -379,6 +436,10 @@ public class BuildSyncRunListener extends RunListener<Run> {
           throw e;
         }
       }
+
+      cause.setNumFlowNodes(newNumFlowNodes);
+      cause.setNumStages(newNumStages);
+      cause.setLastUpdateToOpenshift(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()));
     }
   }
 
@@ -404,6 +465,7 @@ public class BuildSyncRunListener extends RunListener<Run> {
         }
       }
     }
+
     try {
       return new ObjectMapper().writeValueAsString(pendingInputActions);
     } catch (JsonProcessingException e) {


### PR DESCRIPTION
Now build will be updated only when there will be a change
Also, disable the 30 sec. limit of the update. Hence it will update when there will be a change
and will poll at an interval of 5 sec.
#19