### PR TITLE
Fix cancelling build when PR is updated

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
@@ -50,6 +50,8 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
 
   private String skipBranchSuffix;
 
+  private boolean cancelPRBuildOnUpdate = true;
+
   private transient BuildWatcher buildWatcher;
 
   private transient BuildConfigWatcher buildConfigWatcher;
@@ -59,13 +61,14 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
   private transient ConfigMapWatcher configMapWatcher;
 
   @DataBoundConstructor
-  public GlobalPluginConfiguration(boolean enable, String server, String namespace, String jobNamePattern, String skipOrganisationPrefix, String skipBranchSuffix) {
+  public GlobalPluginConfiguration(boolean enable, String server, String namespace, String jobNamePattern, String skipOrganisationPrefix, String skipBranchSuffix, boolean cancelPRbuildOnUpdate) {
     this.enabled = enable;
     this.server = server;
     this.namespace = namespace;
     this.jobNamePattern = jobNamePattern;
     this.skipOrganisationPrefix = skipOrganisationPrefix;
     this.skipBranchSuffix = skipBranchSuffix;
+    this.cancelPRBuildOnUpdate = cancelPRbuildOnUpdate;
     configChange();
   }
 
@@ -140,6 +143,14 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
     this.skipBranchSuffix = skipBranchSuffix;
   }
 
+  public boolean getCancelPRBuildOnUpdate() {
+    return cancelPRBuildOnUpdate;
+  }
+
+  public void setCancelPRBuildOnUpdate(boolean cancelPRBuildOnUpdate) {
+    this.cancelPRBuildOnUpdate = cancelPRBuildOnUpdate;
+  }
+
   private void configChange() {
     if (!enabled) {
       if (buildConfigWatcher != null) {
@@ -206,5 +217,4 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
       }
     }
   }
-
 }

--- a/src/main/resources/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration/config.jelly
+++ b/src/main/resources/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration/config.jelly
@@ -42,5 +42,9 @@
              description="What branch name suffix should we omit from the generated OpenShift BuildConfig resources created by the sync plugin.  Its common to use a common branch name like `master` which we can omit from names to avoid noise.">
       <f:textbox/>
     </f:entry>
+    <f:entry title="Cancel PR Build On Update" field="cancelPRBuildOnUpdate"
+             description="Enabling this feature will cancel the previous build and schedule new one if PR gets updated while the previous build is in progress or in queue">
+      <f:checkbox/>
+    </f:entry>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
This will add the feature of cancelling PR build
if the PR is updated as the previous change is no more
meaningful
If you update a PR which is building it will cancel the build
and will schedule a new one.
If you update a PR whose build in in queue it will
remove that build from queue and schedule new one

Add the flag `cancelPRBuildOnUpdate` to enable this feature
otherwise making this flag false will build all PR updates

Fixes #38
Fixes openshiftio/openshift.io#3862